### PR TITLE
Update drain timeout value

### DIFF
--- a/pkg/test/integration/common/framework.go
+++ b/pkg/test/integration/common/framework.go
@@ -240,6 +240,16 @@ func (c *IntegrationTestFramework) prepareMcmDeployment(
 			// set container image to mcContainerImageTag as the name of the container contains provider
 			if len(mcContainerImage) != 0 {
 				containers[i].Image = mcContainerImage
+				var isOptionAvailable bool
+				for option := range containers[i].Command {
+					if strings.Contains(containers[i].Command[option], "machine-drain-timeout=") {
+						isOptionAvailable = true
+						containers[i].Command[option] = "--machine-drain-timeout=5m"
+					}
+				}
+				if !isOptionAvailable {
+					containers[i].Command = append(containers[i].Command, "--machine-drain-timeout=5m")
+				}
 			}
 		} else {
 			// set container image to mcmContainerImageTag as the name of container contains provider
@@ -758,7 +768,8 @@ func (c *IntegrationTestFramework) ControllerTests() {
 			ginkgo.It("should match with inital resources", func() {
 				// if available, should delete orphaned resources in the cloud provider
 				ginkgo.By("Querrying and comparing")
-				gomega.Expect(c.resourcesTracker.IsOrphanedResourcesAvailable()).To(gomega.BeFalse())
+				gomega.Eventually(c.resourcesTracker.IsOrphanedResourcesAvailable, c.timeout, c.pollingInterval).Should(gomega.BeEquivalentTo(false))
+
 			})
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR
- Updates the `--machine-drain-timeout` value in the MCM instance for integration test to 5 minutes instead of 2 hours
- Also, modifies one test to use `Eventually` instead of just a ginkgo call as tested with Azure and it needs to poll before concluding the call.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Please verify one more time the modified test & let me know if there are any concerns.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
